### PR TITLE
Add stringify: A lightweight C++ library for converting STL container…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,141 @@
+Here’s the updated README with compilation and execution steps included:
+
+---
+
+# stringify
+
+**A lightweight C++ library for converting STL containers into human-readable strings.**
+
+---
+
+### What is `stringify`?
+
+`stringify` is a simple, header-only C++ library that enables you to convert STL containers, such as `vector`, `map`, `queue`, and others, into easy-to-read strings. It is particularly useful for debugging, logging, or any scenario in which you need quick insights into the contents of your containers.
+
+---
+
+### Key Features
+
+- Supports **sequence containers**: `vector`, `deque`, `list`, `forward_list`.
+- Works with **associative containers**: `set`, `unordered_set`, `map`, `unordered_map`.
+- Handles **container adapters**: `stack`, `queue`, `priority_queue`.
+- Header-only: Simply include `stringify.h`—no additional setup or dependencies required.
+- Fast, lightweight, and efficient.
+
+---
+
+### Installation
+
+To use `stringify`, just download `stringify.h` and include it in your project as shown:
+
+```cpp
+#include "stringify.h"
+```
+
+No additional installation steps are needed.
+
+---
+
+### How to Use
+
+Here is a simple example showing how to use the library:
+
+```cpp
+#include "stringify.h"
+#include <vector>
+#include <map>
+#include <stack>
+#include <iostream>
+
+int main() {
+    std::vector<int> vec = {1, 2, 3};
+    std::map<std::string, int> mp = { {"A", 42}, {"B", 84} };
+    std::stack<int> stk;
+    stk.push(100);
+    stk.push(200);
+
+    std::cout << "Vector: " << stringifySeq(vec) << std::endl;
+    std::cout << "Map: " << stringifyAssoc(mp) << std::endl;
+    std::cout << "Stack: " << stringifyStack(stk) << std::endl;
+
+    return 0;
+}
+```
+
+**Output:**
+
+```
+Vector: [1, 2, 3]
+Map: {A: 42, B: 84}
+Stack: [200, 100]
+```
+
+---
+
+### Supported Containers
+
+#### Sequence Containers:
+- `std::vector`
+- `std::deque`
+- `std::list`
+- `std::forward_list`
+
+#### Associative Containers:
+- `std::set`
+- `std::unordered_set`
+- `std::map`
+- `std::unordered_map`
+
+#### Container Adapters:
+- `std::stack`
+- `std::queue`
+- `std::priority_queue`
+
+---
+
+### Why Choose `stringify`?
+
+- **Improved debugging**: Quickly visualize the content of your containers during debugging.
+- **Clean logs**: Make logs more understandable with cleanly formatted container data.
+- **Test-friendly**: Easily compare the string output of containers in test cases to validate results.
+
+---
+
+### Compilation & Execution
+
+To compile and run a program that uses `stringify`, follow these steps:
+
+1. **Download** `stringify.h` and place it in the same directory as your source code, or in a path where your compiler can access it.
+
+2. **Create your source file** (e.g., `main.cpp`) and include `stringify.h`.
+
+3. **Compile the program**. You can use any C++ compiler, like `g++` (for Linux/Mac) or any:
+
+   **For Linux/Mac:**
+   ```bash
+   g++ main.cpp -o program
+   ```
+
+4. **Run the executable**:
+
+   **For Linux/Mac:**
+   ```bash
+   ./program
+   ```
+
+---
+
+### Contributing
+
+We welcome contributions to improve the `stringify` library. You can help by:
+- Submitting pull requests
+- Reporting bugs
+- Suggesting new features or improvements
+
+Your contributions make `stringify` better!
+
+---
+
+### License
+
+This project is licensed under the [GNU General Public License (GPL) v3.0](https://www.gnu.org/licenses/gpl-3.0.html). Please refer to the `LICENSE` file for further details.

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,60 @@
+#include "stringify.h"
+#include <deque>
+#include <forward_list>
+#include <iostream>
+#include <list>
+#include <map>
+#include <queue>
+#include <set>
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+int main()
+{
+    // Sequence containers
+    std::vector<int> vec = {1, 2, 3};
+    std::deque<int> deq = {4, 5, 6};
+    std::list<int> lst = {7, 8, 9};
+    std::forward_list<int> flst = {10, 11, 12};
+
+    std::cout << "Vector: " << stringifySeq(vec) << std::endl;
+    std::cout << "Deque: " << stringifySeq(deq) << std::endl;
+    std::cout << "List: " << stringifySeq(lst) << std::endl;
+    std::cout << "Forward List: " << stringifySeq(flst) << std::endl;
+
+    // Associative containers
+    std::set<int> s = {13, 14, 15};
+    std::unordered_set<int> us = {16, 17, 18};
+    std::map<std::string, int> m = {{"A", 19}, {"B", 20}};
+    std::unordered_map<std::string, int> um = {{"X", 21}, {"Y", 22}};
+
+    std::cout << "Set: " << stringifyAssoc(s) << std::endl;
+    std::cout << "Unordered Set: " << stringifyAssoc(us) << std::endl;
+    std::cout << "Map: " << stringifyAssoc(m) << std::endl;
+    std::cout << "Unordered Map: " << stringifyAssoc(um) << std::endl;
+
+    // Stack
+    std::stack<int> stk;
+    stk.push(23);
+    stk.push(24);
+    stk.push(25);
+    std::cout << "Stack: " << stringifyStack(stk) << std::endl;
+
+    // Queue
+    std::queue<int> q;
+    q.push(26);
+    q.push(27);
+    q.push(28);
+    std::cout << "Queue: " << stringifyQueue(q) << std::endl;
+
+    // Priority Queue
+    std::priority_queue<int> pq;
+    pq.push(29);
+    pq.push(30);
+    pq.push(31);
+    std::cout << "Priority Queue: " << stringifyPQueue(pq) << std::endl;
+
+    return 0;
+}

--- a/stringify.h
+++ b/stringify.h
@@ -1,0 +1,139 @@
+#ifndef STRINGIFY_H
+#define STRINGIFY_H
+
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <map>
+#include <queue>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// Utility function to stringify a sequence container
+template <typename Container> std::string stringifySeq(const Container &container)
+{
+    std::ostringstream oss;
+    oss << "[";
+    for (auto it = container.begin(); it != container.end(); ++it)
+    {
+        if (it != container.begin())
+            oss << ", ";
+        oss << *it;
+    }
+    oss << "]";
+    return oss.str();
+}
+
+// Specialization for forward_list since it lacks reverse iterators
+template <typename T> std::string stringifySeq(const std::forward_list<T> &container)
+{
+    std::ostringstream oss;
+    oss << "[";
+    for (auto it = container.begin(); it != container.end(); ++it)
+    {
+        if (it != container.begin())
+            oss << ", ";
+        oss << *it;
+    }
+    oss << "]";
+    return oss.str();
+}
+
+// Utility function to stringify associative containers
+template <typename Container> std::string stringifyAssoc(const Container &container)
+{
+    std::ostringstream oss;
+    oss << "{";
+    for (auto it = container.begin(); it != container.end(); ++it)
+    {
+        if (it != container.begin())
+            oss << ", ";
+        oss << *it;
+    }
+    oss << "}";
+    return oss.str();
+}
+
+// Specialization for maps to handle key-value pairs
+template <typename Key, typename Value> std::string stringifyAssoc(const std::map<Key, Value> &container)
+{
+    std::ostringstream oss;
+    oss << "{";
+    for (auto it = container.begin(); it != container.end(); ++it)
+    {
+        if (it != container.begin())
+            oss << ", ";
+        oss << it->first << ": " << it->second;
+    }
+    oss << "}";
+    return oss.str();
+}
+
+template <typename Key, typename Value> std::string stringifyAssoc(const std::unordered_map<Key, Value> &container)
+{
+    std::ostringstream oss;
+    oss << "{";
+    for (auto it = container.begin(); it != container.end(); ++it)
+    {
+        if (it != container.begin())
+            oss << ", ";
+        oss << it->first << ": " << it->second;
+    }
+    oss << "}";
+    return oss.str();
+}
+
+// Utility function for stacks
+template <typename T> std::string stringifyStack(std::stack<T> stack)
+{
+    std::ostringstream oss;
+    oss << "[";
+    while (!stack.empty())
+    {
+        oss << stack.top();
+        stack.pop();
+        if (!stack.empty())
+            oss << ", ";
+    }
+    oss << "]";
+    return oss.str();
+}
+
+// Utility function for queues
+template <typename T> std::string stringifyQueue(std::queue<T> queue)
+{
+    std::ostringstream oss;
+    oss << "[";
+    while (!queue.empty())
+    {
+        oss << queue.front();
+        queue.pop();
+        if (!queue.empty())
+            oss << ", ";
+    }
+    oss << "]";
+    return oss.str();
+}
+
+// Utility function for priority queues
+template <typename T> std::string stringifyPQueue(std::priority_queue<T> pq)
+{
+    std::ostringstream oss;
+    oss << "[";
+    while (!pq.empty())
+    {
+        oss << pq.top();
+        pq.pop();
+        if (!pq.empty())
+            oss << ", ";
+    }
+    oss << "]";
+    return oss.str();
+}
+
+#endif // STRINGIFY_H


### PR DESCRIPTION
Add stringify: A lightweight C++ library for converting STL containers into human-readable strings

- Added header-only library to simplify debugging and logging of STL containers
- Supports sequence containers, associative containers, and container adapters
- Includes examples for usage and instructions for compilation and execution
- Licensed under the GNU General Public License v3.0